### PR TITLE
Use year of first publication in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,7 +29,7 @@ Code License
 
 BSD 3-Clause License
 
-Copyright (c) 2023-2024, University College London
+Copyright (c) 2023, University College London
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -55,3 +55,4 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
This PR updates the copyright year in LICENSE.md to use the year of first publication. See also https://hynek.me/til/copyright-years/